### PR TITLE
feat/FHG-5246 - Add Weekly Breakdown Objects to Shared Kernel

### DIFF
--- a/.idea/.idea.fh-shared-kernel/.idea/.gitignore
+++ b/.idea/.idea.fh-shared-kernel/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/.idea.fh-shared-kernel.iml
+/contentModel.xml
+/modules.xml
+/projectSettingsUpdater.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.fh-shared-kernel/.idea/indexLayout.xml
+++ b/.idea/.idea.fh-shared-kernel/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.fh-shared-kernel/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/.idea.fh-shared-kernel/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,13 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="E501" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyUnboundLocalVariableInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/.idea.fh-shared-kernel/.idea/vcs.xml
+++ b/.idea/.idea.fh-shared-kernel/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
+++ b/src/fh-shared-kernel.shared-kernel/FamilyHubs.SharedKernel.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>2.3.1</VersionPrefix>
+    <VersionPrefix>2.3.2</VersionPrefix>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/fh-shared-kernel.shared-kernel/Reports/WeeklyBreakdown/WeeklyReport.cs
+++ b/src/fh-shared-kernel.shared-kernel/Reports/WeeklyBreakdown/WeeklyReport.cs
@@ -1,0 +1,8 @@
+namespace FamilyHubs.SharedKernel.Reports.WeeklyBreakdown;
+
+public class WeeklyReport
+{
+    public string Date { get; init; } = null!;
+
+    public int SearchCount { get; init; }
+}

--- a/src/fh-shared-kernel.shared-kernel/Reports/WeeklyBreakdown/WeeklyReportBreakdown.cs
+++ b/src/fh-shared-kernel.shared-kernel/Reports/WeeklyBreakdown/WeeklyReportBreakdown.cs
@@ -1,0 +1,8 @@
+namespace FamilyHubs.SharedKernel.Reports.WeeklyBreakdown;
+
+public class WeeklyReportBreakdown
+{
+    public IEnumerable<WeeklyReport> WeeklyReports { get; init; } = null!;
+
+    public int TotalSearchCount { get; init; }
+}


### PR DESCRIPTION
The Weekly Breakdown (with Weekly Reports) will be populated by the Report API and consumed by the Manage UI as part of the Reporting KPI work, so I'm adding the objects into the shared kernel